### PR TITLE
Fix: dispatch the event from listener loop overflows the array length

### DIFF
--- a/enchant.js
+++ b/enchant.js
@@ -511,7 +511,7 @@ enchant.EventTarget = enchant.Class.create({
         if (listeners == null) {
             this._listeners[type] = [listener];
         } else if (listeners.indexOf(listener) == -1) {
-            listeners.push(listener);
+            listeners.unshift(listener);
         }
     },
     /**
@@ -539,7 +539,7 @@ enchant.EventTarget = enchant.Class.create({
         if (this['on' + e.type] != null) this['on' + e.type]();
         var listeners = this._listeners[e.type];
         if (listeners != null) {
-            for (var i = 0, len = listeners.length; i < len; i++) {
+            while (i--) {
                 listeners[i].call(this, e);
             }
         }


### PR DESCRIPTION
listener を実行中に削除した場合、ループの最後で存在しなくなった項目をよみにいってしまいます。
listener の呼出を配列の最後からおこない、それにあわせて追加時に unshift を使うことで解決しました。
