### PR TITLE
Spriteの現在のframe値を更新する

### DIFF
--- a/dev/enchant.js
+++ b/dev/enchant.js
@@ -2400,6 +2400,7 @@ enchant.Sprite = enchant.Class.create(enchant.Entity, {
     },
     _setFrame: function(frame){
         if (this._image != null){
+            this._frame = frame
             var row = this._image.width / this._width | 0;
             if (this._image._css) {
                 this._style.backgroundPosition = [


### PR DESCRIPTION
Sprite.frameのgetterが常に0を返していたのでframeの更新時にthis._frameに値を保持するよう修正しました
