### PR TITLE
sprite.enchant.jsでSpriteの回転が正しく表示されない問題の解決

### DIFF
--- a/plugins/canvas.enchant.js
+++ b/plugins/canvas.enchant.js
@@ -48,18 +48,30 @@ enchant.CanvasGroup = enchant.Class.create(enchant.Group,{
 			node._dh = 	~~(node.height*node.scaleY);
 			if((node._image.width==node.width)&&(node.scaleX==1&&node.scaleY==1)){
 				node.draw = function(context){
-						context.drawImage(this.image._element,
-							this.x+this._dx,
-							this.y+this._dy);					
+                    context.save();
+                    var rad = this._rotation * Math.PI / 180;
+                    context.translate(this.x + this._dw/2,
+                                      this.y + this._dh/2);
+                    context.rotate(rad);
+					context.drawImage(this.image._element,
+							          this._dw/-2,
+							          this._dh/-2);
+                    context.restore();
 				}
 			}else{
 				node.draw = function(context){
+                    context.save();
+                    var rad = this._rotation * Math.PI / 180;
+                    context.translate(this.x + this._dw/2,
+                                      this.y + this._dh/2);
+                    context.rotate(rad);
 					context.drawImage(this.image._element,
-						this._sx,this._sy,
-						this._sw,this._sh,
-						this.x+this._dx,
-						this.y+this._dy,
-						this._dw,this._dh);	
+						              this._sx,this._sy,
+						              this._sw,this._sh,
+						              this._dw/-2,
+							          this._dh/-2,
+						              this._dw,this._dh);	
+                    context.restore();
 				}
 			}
 		};


### PR DESCRIPTION
こんにちは。昨日のenchant.js meetup vol.2ではお世話になりました。

さて、CanvasGroupにaddChildしたSpriteに rotation が回転が指定されている場合にも、
回転をしていない状態での画像が表示されてしまう問題があることに気づきました。

そこで、canvas.enchant.jsの内部でdrawImageを呼び出す際の引数内容を見直し、
その直前にtranslate,rotateの呼び出しを追加することで修正をしてみましたので、
もしよろしければ反映をしていただければと思います。

(インデントがずれてしまって汚いのですが、すみません…直していただけると幸いです)
