### PR TITLE
Start using Travis CI to verify regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 0.8

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ enchant.js
 
 JavaScript Game Engine
 
+[![Build Status](https://secure.travis-ci.org/wise9/enchant.js.png)](https://travis-ci.org/wise9/enchant.js)
+
 Download
 --------
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "enchant.js",
+  "version": "0.5.2",
+  "engines": {
+    "node": ">=0.8"
+  },
+  "scripts": {
+    "test": "grunt default --verbose"
+  },
+  "devDependencies": {
+    "grunt": "0.3.17",
+    "grunt-exec": "0.3.0"
+  }
+}


### PR DESCRIPTION
Grunt makes build process easy, so I think it's a good chance to start CI.
I think [Travis CI](https://travis-ci.org/) is the best choice for community. In my opinion, [Buildhive](https://buildhive.cloudbees.com/) is not good for JS project.

Please check [example](https://travis-ci.org/eller86/enchant.js) to know how Travis CI works for enchant.js.
You (wise9 account) have to [activate GitHub service hook](http://about.travis-ci.org/docs/user/getting-started/) to start using Travis CI.

This change also enables us to use `npm install` to set up development environment.
