### PR TITLE
Previous translations moved to source

### DIFF
--- a/dev/enchant.js
+++ b/dev/enchant.js
@@ -1295,8 +1295,8 @@ enchant.Event.B_BUTTON_UP = 'bbuttonup';
  * looped が設定されている時も、アクションは一度タイムラインから削除されもう一度追加される
  [/lang]
  [lang:en]
- * An event dispatched when an Action has been added to a Timeline.
- * When looped, an Action is removed from the timeline and added back into it.
+ * An event dispatched when an Action is added to a Timeline.
+ * When looped, an Action is removed from the Timeline and added back into it.
  [/lang]
  * @type {String}
  *
@@ -1695,7 +1695,7 @@ enchant.EventTarget = enchant.Class.create({
              * ロードされた画像をパスをキーとして保存するオブジェクト.
              [/lang]
              [lang:en]
-             * Object which stores loaded assets using the path as a key.
+             * Object which stores loaded assets using their paths as keys.
              [/lang]
              [lang:de]
              * Geladene Objekte werden unter dem Pfad als Schlüssel in diesem Objekt abgelegt.
@@ -2225,7 +2225,7 @@ enchant.EventTarget = enchant.Class.create({
          [lang:ja]
          * アプリを起動する.
          *
-         * enchant.Core#fpsで設定されたフレームレートに従ってenchant.Core#currentSceneの
+         * enchant.Core#fpsで設定されたフレームレートに従って{@link enchant.Core#currentScene}の
          * フレームの更新が行われるようになる. プリロードする画像が存在する場合はロードが
          * 始まりローディング画面が表示される.
          [/lang]

--- a/dev/src/Core.js
+++ b/dev/src/Core.js
@@ -15,20 +15,21 @@
          *
          * インスタンスは一つしか存在することができず, すでにインスタンスが存在する状態で
          * コンストラクタを実行した場合既存のものが上書きされる. 存在するインスタンスには
-         * enchant.Core.instanceからアクセスできる.
+         * {@link enchant.Core.instance}からアクセスできる.
          *
-         * @param {Number} width 画面の横幅.
-         * @param {Number} height 画面の高さ.
+         * @param {Number} [width] 画面の横幅.
+         * @param {Number} [height] 画面の高さ.
          [/lang]
          [lang:en]
-         * A class which is controlling the cores main loop and scenes.
+         * A class for controlling the core’s main loop and scenes.
          *
-         * There can be only one instance at a time, when the constructor is executed
-         * with an instance present, the existing instance will be overwritten. The existing instance
+         * There can be only one instance at a time. When the
+         * constructor is executed while an instance exists, the
+         * existing instance will be overwritten. The existing instance
          * can be accessed from {@link enchant.Core.instance}.
          *
-         * @param {Number} width The width of the core screen.
-         * @param {Number} height The height of the core screen.
+         * @param {Number} [width] The width of the core viewport.
+         * @param {Number} [height] The height of the core viewport.
          [/lang]
          [lang:de]
          * Klasse, welche die Spielschleife und Szenen kontrolliert.
@@ -38,8 +39,8 @@
          * Auf die aktuell existierende Instanz kann über die {@link enchant.Core.instance}
          * Variable zugegriffen werden.
          *
-         * @param {Number} width Die Breite des Spieles.
-         * @param {Number} height Die Höhe des Spieles.
+         * @param {Number} [width] Die Breite des Spieles.
+         * @param {Number} [height] Die Höhe des Spieles.
          [/lang]
          * @constructs
          * @extends enchant.EventTarget
@@ -136,7 +137,7 @@
              * アプリの開始からのフレーム数.
              [/lang]
              [lang:en]
-             * The amount of frames since the core was started.
+             * The number of frames processed since the core was started.
              [/lang]
              [lang:de]
              * Anzahl der Frames seit dem Spielestart.
@@ -149,7 +150,7 @@
              * アプリが実行可能な状態かどうか.
              [/lang]
              [lang:en]
-             * Indicates if the core can be executed.
+             * Indicates whether or not the core can be executed.
              [/lang]
              [lang:de]
              * Zeigt an ob das Spiel ausgeführt werden kann.
@@ -162,7 +163,7 @@
              * アプリが実行状態かどうか.
              [/lang]
              [lang:en]
-             * Indicates if the core is currently executed.
+             * Indicates whether or not the core is currently running.
              [/lang]
              [lang:de]
              * Zeigt an ob das Spiel derzeit ausgeführt wird.
@@ -175,7 +176,7 @@
              * ロードされた画像をパスをキーとして保存するオブジェクト.
              [/lang]
              [lang:en]
-             * Object which stores loaded objects with the path as key.
+             * Object which stores loaded assets using their paths as keys.
              [/lang]
              [lang:de]
              * Geladene Objekte werden unter dem Pfad als Schlüssel in diesem Objekt abgelegt.
@@ -202,7 +203,7 @@
              * 現在のScene. Sceneスタック中の一番上のScene.
              [/lang]
              [lang:en]
-             * The Scene which is currently displayed. This Scene is on top of Scene stack.
+             * The Scene which is currently displayed. This Scene is on top of the Scene stack.
              [/lang]
              [lang:de]
              * Die aktuell dargestellte Szene.
@@ -216,7 +217,7 @@
              * ルートScene. Sceneスタック中の一番下のScene.
              [/lang]
              [lang:en]
-             * The root Scene. The Scene at bottom of Scene stack.
+             * The root Scene. The Scene at the bottom of the Scene stack.
              [/lang]
              [lang:de]
              * Die Ursprungsszene.
@@ -231,7 +232,7 @@
              * ローディング時に表示されるScene.
              [/lang]
              [lang:en]
-             * The Scene which is getting displayed during loading.
+             * The Scene to be displayed during loading.
              [/lang]
              [lang:de]
              * Die Szene, welche während des Ladevorgangs dargestellt wird.
@@ -243,6 +244,9 @@
             /**
              [lang:ja]
              * 一度でも game.start() が呼ばれたことがあるかどうか。
+             [/lang]
+             [/lang:ja]
+             * Indicates whether or not game.start() has been called.
              [/lang]
              * @type {Boolean}
              * @private
@@ -521,13 +525,13 @@
          [lang:ja]
          * ファイルのプリロードを行う.
          *
-         * プリロードを行うよう設定されたファイルはenchant.Core#startが実行されるとき
+         * プリロードを行うよう設定されたファイルは{@link enchant.Core#start}が実行されるとき
          * ロードが行われる. 全てのファイルのロードが完了したときはCoreオブジェクトからload
          * イベントが発行され, Coreオブジェクトのassetsプロパティから画像ファイルの場合は
          * Surfaceオブジェクトとして, 音声ファイルの場合はSoundオブジェクトとして,
          * その他の場合は文字列としてアクセスできるようになる.
          *
-         * なおこのSurfaceオブジェクトはenchant.Surface.loadを使って作成されたものである
+         * なおこのSurfaceオブジェクトは{@link enchant.Surface.load}を使って作成されたものである
          * ため直接画像操作を行うことはできない. enchant.Surface.loadの項を参照.
          *
          * @example
@@ -539,20 +543,27 @@
          *   };
          *   core.start();
          *
-         * @param {...String} assets プリロードする画像のパス. 複数指定できる.
+         * @param {...String} [assets] プリロードするファイルのパス. 複数指定できる.
          [/lang]
          [lang:en]
-         * Performs a file preload.
+         * File preloader.
          *
-         * Sets files which are to be preloaded. When {@link enchant.Core#start} is called the
-         * actual loading takes place. When all files are loaded, a {@link enchant.Event.LOAD} event
-         * is dispatched from the Core object. Depending on the type of the file different objects will be
-         * created and stored in {@link enchant.Core#assets} Variable.
-         * When an image file is loaded, an {@link enchant.Surface} is created. If a sound file is loaded, an
-         * {@link enchant.Sound} object is created. Otherwise it will be accessible as a string.
+         * Loads the files specified in the parameters when
+         * {@link enchant.Core#start} is called.
+         * When all files are loaded, a {@link enchant.Event.LOAD}
+         * event is dispatched from the Core object. Depending on the
+         * type of each file, different objects will be created and
+         * stored in {@link enchant.Core#assets} Variable.
          *
-         * In addition, because this Surface object used made with {@link enchant.Surface.load},
-         * direct object manipulation is not possible. Refer to the items of {@link enchant.Surface.load}
+         * When an image file is loaded, a {@link enchant.Surface} is
+         * created. If a sound file is loaded, an {@link enchant.Sound}
+         * object is created. Any other file type will be accessible
+         * as a string.
+         *
+         * In addition, because this Surface object is created with
+         * {@link enchant.Surface.load}, it is not possible to
+         * manipulate the image directly.
+         * Refer to the {@link enchant.Surface.load} documentation.
          *
          * @example
          *   core.preload('player.gif');
@@ -563,7 +574,8 @@
          *   };
          *   core.start();
          *
-         * @param {...String} assets Path of images to be preloaded. Multiple settings possible.
+         * @param {...String} [assets] Path of images to be preloaded.
+         * Multiple settings possible.
          [/lang]
          [lang:de]
          * Lässt Dateien im voraus laden.
@@ -589,7 +601,7 @@
          *   };
          *   core.start();
          *
-         * @param {...String} assets Pfade zu den Dateien die im voraus geladen werden sollen.
+         * @param {...String} [assets] Pfade zu den Dateien die im voraus geladen werden sollen.
          * Mehrfachangaben möglich.
          [/lang]
          * @return {enchant.Core} this
@@ -616,7 +628,7 @@
          [lang:ja]
          * ファイルのロードを行う.
          *
-         * @param {String} asset ロードするファイルのパス.
+         * @param {String} [src] asset ロードするファイルのパス.
          * @param {String} [alias] ロードするファイルに設定したい名前.
          * @param {Function} [callback] ファイルのロードが完了したときに呼び出される関数.
          * @param {Function} [onerror] ファイルのロードに失敗したときに呼び出される関数.
@@ -624,15 +636,15 @@
          [lang:en]
          * Loads a file.
          *
-         * @param {String} asset File path of the resource to be loaded.
-         * @param {String} asset name of the resource to be loaded.
-         * @param {Function} [callback] Function called up when file loading is finished.
-         * @param {Function} [callback] Function called up when file loading is failed.
+         * @param {String} [src] File path of the resource to be loaded.
+         * @param {String} [asset] Name you want to designate for the resource to be loaded.
+         * @param {Function} [callback] Function to be called if the file loads successfully.
+         * @param {Function} [onerror] Function to be called if the file fails to load.
          [/lang]
          [lang:de]
          * Laden von Dateien.
          *
-         * @param {String} asset Pfad zu der Datei die geladen werden soll.
+         * @param {String} [asset] Pfad zu der Datei die geladen werden soll.
          * @param {Function} [callback] Funktion die ausgeführt wird wenn das laden abgeschlossen wurde.
          [/lang]
          */
@@ -694,16 +706,17 @@
          [lang:ja]
          * アプリを起動する.
          *
-         * enchant.Core#fpsで設定されたフレームレートに従ってenchant.Core#currentSceneの
+         * enchant.Core#fpsで設定されたフレームレートに従って{@link enchant.Core#currentScene}の
          * フレームの更新が行われるようになる. プリロードする画像が存在する場合はロードが
          * 始まりローディング画面が表示される.
          [/lang]
          [lang:en]
          * Start the core.
          *
-         * Obeying the frame rate set in {@link enchant.Core#fps}, the frame in
-         * {@link enchant.Core#currentScene} will be updated. If images to preload are present,
-         * loading will begin and the loading screen will be displayed.
+         * Sets the framerate of the {@link enchant.Core#currentScene}
+         * according to the value stored in {@link enchant.core#fps}. If
+         * there are images to preload, loading will begin and the
+         * loading screen will be displayed.
          [/lang]
          [lang:de]
          * Starte das Spiel
@@ -807,10 +820,10 @@
          * enchant.Core.instance._debug フラグを true にすることでもデバッグモードをオンにすることができる
          [/lang]
          [lang:en]
-         * Begin core debug mode.
+         * Start application in debug mode.
          *
-         * Core debug mode can be set to on even if enchant.Core.instance._debug
-         * flag is already set to true.
+         * Core debug mode can be turned on even if the
+         * enchant.Core.instance._debug flag is already set to true.
          [/lang]
          [lang:de]
          * Startet den Debug-Modus des Spieles.
@@ -832,7 +845,11 @@
         /**
          [lang:ja]
          * 次のフレームの実行を要求する.
-         * @param {Number} requestAnimationFrameを呼び出すまでの遅延時間.
+         * @param {Number} [delay] requestAnimationFrameを呼び出すまでの遅延時間.
+         [/lang]
+         [lang:en]
+         * Requests the next frame.
+         * @param {Number} [delay] Amount of time to delay before calling requestAnimationFrame.
          [/lang]
          * @private
          */
@@ -855,6 +872,10 @@
          [lang:ja]
          * Core#_tickを呼び出す.
          [/lang]
+         [lang:en]
+         * Calls {@link enchant.Core#_tick}.
+         [/lang]
+         * @param {Number} [time]
          * @private
          */
         _callTick: function(time) {
@@ -896,7 +917,7 @@
          * アプリを停止する.
          *
          * フレームは更新されず, ユーザの入力も受け付けなくなる.
-         * enchant.Core#startで再開できる.
+         * {@link enchant.Core#start}で再開できる.
          [/lang]
          [lang:en]
          * Stops the core.
@@ -921,7 +942,7 @@
          * アプリを一時停止する.
          *
          * フレームは更新されず, ユーザの入力は受け付ける.
-         * enchant.Core#startで再開できる.
+         * {@link enchant.Core#start}で再開できる.
          [/lang]
          [lang:en]
          * Stops the core.
@@ -945,7 +966,7 @@
          * アプリを再開する。
          [/lang]
          [lang:en]
-         * Resumes the core.
+         * Resumes core operations.
          [/lang]
          [lang:de]
          * Setzt die Ausführung des Spieles fort.
@@ -969,17 +990,19 @@
          * enchant.Core#pushSceneを行うとSceneをスタックの一番上に積むことができる. スタックの
          * 一番上のSceneに対してはフレームの更新が行われる.
          *
-         * @param {enchant.Scene} scene 移行する新しいScene.
+         * @param {enchant.Scene} [scene] 移行する新しいScene.
          * @return {enchant.Scene} 新しいScene.
          [/lang]
          [lang:en]
-         * Switch to a new Scene.
+         * Switches to a new Scene.
          *
-         * Scenes are controlled using a stack, and the display order also obeys that stack order.
-         * When {@link enchant.Core#pushScene} is executed, the Scene can be brought to the top of stack.
-         * Frames will be updated in the Scene which is on the top of the stack.
+         * Scenes are controlled using a stack, with the top scene on
+         * the stack being the one displayed.
+         * When {@link enchant.Core#pushScene} is executed, the Scene is
+         * placed top of the stack. Frames will be only updated for the
+         * Scene which is on the top of the stack.
          *
-         * @param {enchant.Scene} scene The new scene to be switched to.
+         * @param {enchant.Scene} [scene] The new scene to display.
          * @return {enchant.Scene} The new Scene.
          [/lang]
          [lang:de]
@@ -1014,13 +1037,14 @@
          * @return {enchant.Scene} 終了させたScene.
          [/lang]
          [lang:en]
-         * Ends the current Scene, return to the previous Scene.
+         * Ends the current Scene and returns to the previous Scene.
          *
-         * Scenes are controlled using a stack, and the display order also obeys that stack order.
-         * When {@link enchant.Core#popScene} is executed, the Scene at the top of the stack
-         * will be removed and returned.
+         * Scenes are controlled using a stack, with the top scene on
+         * the stack being the one displayed.
+         * When {@link enchant.Core#popScene} is executed, the Scene at
+         * the top of the stack is removed and returned.
          *
-         * @return {enchant.Scene} Ended Scene.
+         * @return {enchant.Scene} Removed Scene.
          [/lang]
          [lang:de]
          * Beendet die aktuelle Szene und wechselt zu der vorherigen Szene.
@@ -1047,18 +1071,18 @@
          [lang:ja]
          * 現在のSceneを別のSceneにおきかえる.
          *
-         * enchant.Core#popScene, enchant.Core#pushSceneを同時に行う.
+         * {@link enchant.Core#popScene}, {@link enchant.Core#pushScene}を同時に行う.
          *
-         * @param {enchant.Scene} scene おきかえるScene.
+         * @param {enchant.Scene} [scene] おきかえるScene.
          * @return {enchant.Scene} 新しいScene.
          [/lang]
          [lang:en]
          * Overwrites the current Scene with a new Scene.
          *
-         * {@link enchant.Core#popScene}, {@link enchant.Core#pushScene} are executed after
-         * each other to replace to current scene with the new scene.
+         * Executes {@link enchant.Core#popScene} and {@link enchant.Core#pushScene}
+         * one after another to replace the current scene with the new scene.
          *
-         * @param {enchant.Scene} scene The new scene which will replace the previous scene.
+         * @param {enchant.Scene} [scene] The new scene with which to replace the current scene.
          * @return {enchant.Scene} The new Scene.
          [/lang]
          [lang:de]
@@ -1067,7 +1091,7 @@
          * {@link enchant.Core#popScene}, {@link enchant.Core#pushScene} werden nacheinander
          * ausgeführt um die aktuelle Szene durch die neue zu ersetzen.
          *
-         * @param {enchant.Scene} scene Die neue Szene, welche die aktuelle Szene ersetzen wird.
+         * @param {enchant.Scene} [scene] Die neue Szene, welche die aktuelle Szene ersetzen wird.
          * @return {enchant.Scene} Die neue Szene.
          [/lang]
          */
@@ -1081,15 +1105,18 @@
          *
          * Sceneスタック中からSceneを削除する.
          *
-         * @param {enchant.Scene} scene 削除するScene.
+         * @param {enchant.Scene} [scene] 削除するScene.
          * @return {enchant.Scene} 削除したScene.
          [/lang]
          [lang:en]
-         * Removes a Scene.
-         *
          * Removes a Scene from the Scene stack.
          *
-         * @param {enchant.Scene} scene Scene to be removed.
+         * If the scene passed in as a parameter is not the current
+         * scene, the stack will be searched for the given scene.
+         * If the given scene does not exist anywhere in the stack,
+         * this method returns null.
+         *
+         * @param {enchant.Scene} [scene] Scene to be removed.
          * @return {enchant.Scene} The deleted Scene.
          [/lang]
          [lang:de]
@@ -1097,7 +1124,7 @@
          *
          * Entfernt eine Szene aus dem Szenen-Stapelspeicher.
          *
-         * @param {enchant.Scene} scene Die Szene die entfernt werden soll.
+         * @param {enchant.Scene} [scene] Die Szene die entfernt werden soll.
          * @return {enchant.Scene} Die entfernte Szene.
          [/lang]
          */
@@ -1119,20 +1146,23 @@
          [lang:ja]
          * キーバインドを設定する.
          *
-         * @param {Number} key キーバインドを設定するキーコード.
-         * @param {String} button 割り当てるボタン.
+         * @param {Number} [key] キーバインドを設定するキーコード.
+         * @param {String} [button] 割り当てるボタン.
          [/lang]
          [lang:en]
-         * Set a key binding.
+         * Bind a key code to an enchant.js button.
          *
-         * @param {Number} key Key code for the button which will be bound.
-         * @param {String} button The enchant.js button (left, right, up, down, a, b).
+         * Binds the given key code to the given enchant.js button
+         * ('left', 'right', 'up', 'down', 'a', 'b').
+         *
+         * @param {Number} [key] Key code for the button to be bound.
+         * @param {String} [button] An enchant.js button.
          [/lang]
          [lang:de]
          * Bindet eine Taste.
          *
-         * @param {Number} key Der Tastencode der Taste die gebunden werden soll.
-         * @param {String} button Der enchant.js Knopf (left, right, up, down, a, b).
+         * @param {Number} [key] Der Tastencode der Taste die gebunden werden soll.
+         * @param {String} [button] Der enchant.js Knopf (left, right, up, down, a, b).
          [/lang]
          * @return {enchant.Core} this
          */
@@ -1172,14 +1202,14 @@
          * @param {Number} key 削除するキーコード.
          [/lang]
          [lang:en]
-         * Delete a key binding.
+         * Delete the key binding for the given key.
          *
-         * @param {Number} key Key code that want to delete.
+         * @param {Number} [key] Key code whose binding is to be deleted.
          [/lang]
          [lang:de]
          * Entbindet eine Taste.
          *
-         * @param {Number} key Der Tastencode der entfernt werden soll.
+         * @param {Number} [key] Der Tastencode der entfernt werden soll.
          [/lang]
          * @return {enchant.Core} this
          */
@@ -1206,8 +1236,8 @@
          * @return {Number} 経過した時間 (秒)
          [/lang]
          [lang:en]
-         * Get the elapsed core time (not actual) from when core.start was called.
-         * @return {Number} The elapsed time (seconds)
+         * Get the core time (not actual) elapsed since core.start was called.
+         * @return {Number} Time elapsed (in seconds).
          [/lang]
          [lang:de]
          * Liefert die vergange Spielzeit (keine reale) die seit dem Aufruf von core.start
@@ -1226,6 +1256,12 @@
      * ロード関数はファイルのパス, 拡張子, コールバックを引数に取り,
      * 対応したクラスのインスタンスを返す必要がある.
      * コールバックはEvent.LOADとEvent.ERRORでハンドルする.
+     [/lang]
+     [lang:en]
+     * Functions for loading assets of the corresponding file type.
+     * The loading functions must take the file path, extension and
+     * callback function as arguments, then return the appropriate
+     * class instance.
      [/lang]
      * @static
      * @private
@@ -1249,7 +1285,7 @@
 
     /**
      * Get the file extension from a path
-     * @param path
+     * @param {String} [path]
      * @return {*}
      */
     enchant.Core.findExt = function(path) {
@@ -1270,7 +1306,7 @@
      * 現在のCoreインスタンス.
      [/lang]
      [lang:en]
-     * The Current Core instance.
+     * The current Core instance.
      [/lang]
      [lang:de]
      * Die aktuelle Instanz des Spieles.

--- a/dev/src/Env.js
+++ b/dev/src/Env.js
@@ -5,7 +5,8 @@
  * new Core() を呼ぶ前に変更することで変更することで, 動作設定を変えることができる.
  [/lang]
  [lang:en]
- * Environment variable.
+ * enchant.js environment variables.
+ * Execution settings can be changed by modifying these before calling new Core().
  [/lang]
  [lang:de]
  * Umgebungsvariable.

--- a/dev/src/Event.js
+++ b/dev/src/Event.js
@@ -11,9 +11,8 @@ enchant.Event = enchant.Class.create({
      * @param {String} type Eventのタイプ
      [/lang]
      [lang:en]
-     * A class for an independent implementation of events
-     * similar to DOM Events.
-     * However, it does not include phase concept.
+     * A class for an independent implementation of events similar to DOM Events.
+     * Does not include phase concepts.
      * @param {String} type Event type.
      [/lang]
      [lang:de]
@@ -56,7 +55,7 @@ enchant.Event = enchant.Class.create({
          * イベント発生位置のx座標.
          [/lang]
          [lang:en]
-         * The x coordinate of the events occurrence.
+         * The x-coordinate of the event's occurrence.
          [/lang]
          [lang:de]
          * X Koordinate des Auftretens des Ereignis.
@@ -69,7 +68,7 @@ enchant.Event = enchant.Class.create({
          * イベント発生位置のy座標.
          [/lang]
          [lang:en]
-         * The y coordinate of the events occurrence.
+         * The y-coordinate of the event's occurrence.
          [/lang]
          [lang:de]
          * Y Koordinate des Auftretens des Ereignis.
@@ -82,7 +81,8 @@ enchant.Event = enchant.Class.create({
          * イベントを発行したオブジェクトを基準とするイベント発生位置のx座標.
          [/lang]
          [lang:en]
-         * The event occurrences local coordinate systems x coordinates.
+         * The x-coordinate of the event's occurrence relative to the object
+         * which issued the event.
          [/lang]
          [lang:de]
          * X Koordinate des lokalen Koordinatensystems des Auftretens des Ereignis.
@@ -95,7 +95,8 @@ enchant.Event = enchant.Class.create({
          * イベントを発行したオブジェクトを基準とするイベント発生位置のy座標.
          [/lang]
          [lang:en]
-         * The event occurrences local coordinate systems y coordinates.
+         * The y-coordinate of the event's occurrence relative to the object
+         * which issued the event.
          [/lang]
          [lang:de]
          * Y Koordinate des lokalen Koordinatensystems des Auftretens des Ereignis.
@@ -128,10 +129,11 @@ enchant.Event = enchant.Class.create({
  *
  [/lang]
  [lang:en]
- * An event dispatched upon completion of core loading.
+ * An event dispatched once the core has finished loading.
  *
- * It is necessary to wait for loading to finish and to do initial processing when preloading images.
- * Issued object: {@link enchant.Core}
+ * When preloading images, it is necessary to wait until preloading is complete
+ * before starting the game.
+ * Issued by: {@link enchant.Core}
  *
  * @example
  *   var core = new Core(320, 320);
@@ -168,8 +170,8 @@ enchant.Event.LOAD = 'load';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Surface}, {@link enchant.WebAudioSound}, {@link enchant.DOMSound}
  [/lang]
  [lang:en]
- * Events which are occurring when error is occured.
- * Issued object: {@link enchant.Core}, {@link enchant.Surface}, {@link enchant.WebAudioSound}, {@link enchant.DOMSound}
+ * An event dispatched when an error occurs.
+ * Issued by: {@link enchant.Core}, {@link enchant.Surface}, {@link enchant.WebAudioSound}, {@link enchant.DOMSound}
  [/lang]
  */
 enchant.Event.ERROR = 'error';
@@ -180,8 +182,8 @@ enchant.Event.ERROR = 'error';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * Events which are occurring when display size is changed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the display size is changed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  @type {String}
  */
@@ -193,8 +195,9 @@ enchant.Event.CORE_RESIZE = 'coreresize';
  * プリロードする画像が一枚ロードされる度に発行される. 発行するオブジェクト: {@link enchant.LoadingScene}
  [/lang]
  [lang:en]
- * Events which are occurring during core loading.
- * Dispatched each time preloaded image is loaded. Issued object: {@link enchant.LoadingScene}
+ * An event dispatched while the core is loading.
+ * Dispatched each time an image is preloaded.
+ * Issued by: {@link enchant.LoadingScene}
  [/lang]
  [lang:de]
  * Ereignis, welches während des Ladens des Spieles auftritt.
@@ -228,8 +231,8 @@ enchant.Event.ENTER_FRAME = 'enterframe';
  * 発行するオブジェクト: {@link enchant.Core}
  [/lang]
  [lang:en]
- * An event which is occurring when the frame processing is about to end.
- * Issued object: {@link enchant.Core}
+ * An event dispatched at the end of processing a new frame.
+ * Issued by: {@link enchant.Core}, {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welches auftritt wenn ein Frame beendet wird.
@@ -245,8 +248,8 @@ enchant.Event.EXIT_FRAME = 'exitframe';
  * 発行するオブジェクト: {@link enchant.Scene}
  [/lang]
  [lang:en]
- * Events occurring during Scene beginning.
- * Issued object: {@link enchant.Scene}
+ * An event dispatched when a Scene begins.
+ * Issued by: {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, dass auftritt wenn eine neue Szene
@@ -263,8 +266,8 @@ enchant.Event.ENTER = 'enter';
  * 発行するオブジェクト: {@link enchant.Scene}
  [/lang]
  [lang:en]
- * Events occurring during Scene end.
- * Issued object: {@link enchant.Scene}
+ * An event dispatched when a Scene ends.
+ * Issued by: {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, dass auftritt wenn eine Szene
@@ -281,8 +284,8 @@ enchant.Event.EXIT = 'exit';
  * 発行するオブジェクト: {@link enchant.Group}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when a Child is getting added to a Node.
- * Issued object: {@link enchant.Group}, {@link enchant.Scene}
+ * An event dispatched when a Child is added to a Node.
+ * Issued by: {@link enchant.Group}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn ein Kindelement zu einem Node
@@ -299,8 +302,8 @@ enchant.Event.CHILD_ADDED = 'childadded';
  * 発行するオブジェクト: {@link enchant.Node}
  [/lang]
  [lang:en]
- * An event which is occurring when the Node is added to a Group.
- * Issued object: {@link enchant.Node}
+ * An event dispatched when a Node is added to a Group.
+ * Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der Node zu einer Gruppe
@@ -317,8 +320,8 @@ enchant.Event.ADDED = 'added';
  * 発行するオブジェクト: {@link enchant.Node}
  [/lang]
  [lang:en]
- * An event which is occurring when the Node is added to a Scene.
- * Issued object: {@link enchant.Node}
+ * An event dispatched when a Node is added to a Scene.
+ * Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der Node zu einer Szene
@@ -336,8 +339,8 @@ enchant.Event.ADDED_TO_SCENE = 'addedtoscene';
  * @type {String}
  [/lang]
  [lang:en]
- * An event which is occurring when a Child is removed from a Node.
- * Issued object: {@link enchant.Group}, {@link enchant.Scene}
+ * An event dispatched when a Child is removed from a Node.
+ * Issued by: {@link enchant.Group}, {@link enchant.Scene}
  * @type {String}
  [/lang]
  [lang:de]
@@ -355,8 +358,8 @@ enchant.Event.CHILD_REMOVED = 'childremoved';
  * 発行するオブジェクト: {@link enchant.Node}
  [/lang]
  [lang:en]
- * An event which is occurring when the Node is deleted from a Group.
- * Issued object: {@link enchant.Node}
+ * An event dispatched when a Node is deleted from a Group.
+ * Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der Node aus einer Gruppe
@@ -373,8 +376,8 @@ enchant.Event.REMOVED = 'removed';
  * 発行するオブジェクト: {@link enchant.Node}
  [/lang]
  [lang:en]
- * An event which is occurring when the Node is deleted from a Scene.
- * Issued object: {@link enchant.Node}
+ * An event dispatched when a Node is deleted from a Scene.
+ * Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der Node aus einer Szene
@@ -391,8 +394,8 @@ enchant.Event.REMOVED_FROM_SCENE = 'removedfromscene';
  * クリックもタッチとして扱われる. 発行するオブジェクト: {@link enchant.Node}
  [/lang]
  [lang:en]
- * An event occurring when a touch related to the Node has begun.
- * A click is also treated as touch. Issued object: {@link enchant.Node}
+ * An event dispatched when a touch event intersecting a Node begins.
+ * A mouse event counts as a touch event. Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn ein Touch auf einen Node
@@ -409,8 +412,8 @@ enchant.Event.TOUCH_START = 'touchstart';
  * クリックもタッチとして扱われる. 発行するオブジェクト: {@link enchant.Node}
  [/lang]
  [lang:en]
- * An event occurring when a touch related to the Node has been moved.
- * A click is also treated as touch. Issued object: {@link enchant.Node}
+ * An event dispatched when a touch event intersecting the Node has been moved.
+ * A mouse event counts as a touch event. Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn ein Touch auf einen Node
@@ -427,8 +430,8 @@ enchant.Event.TOUCH_MOVE = 'touchmove';
  * クリックもタッチとして扱われる. 発行するオブジェクト: enchant.Node
  [/lang]
  [lang:en]
- * An event which is occurring when a touch related to the Node has ended.
- * A Click is also treated as touch. Issued object: enchant.Node
+ * An event dispatched when a touch event intersecting the Node ends.
+ * A mouse event counts as a touch event. Issued by: {@link enchant.Node}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn ein Touch auf einen Node
@@ -445,8 +448,8 @@ enchant.Event.TOUCH_END = 'touchend';
  * 発行するオブジェクト: {@link enchant.Entity}
  [/lang]
  [lang:en]
- * An event which is occurring when an Entity is rendered.
- * Issued object: {@link enchant.Entity}
+ * An event dispatched when an Entity is rendered.
+ * Issued by: {@link enchant.Entity}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn eine Entity
@@ -463,8 +466,8 @@ enchant.Event.RENDER = 'render';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when a button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when a button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn ein Knopf gedückt wird.
@@ -480,8 +483,8 @@ enchant.Event.INPUT_START = 'inputstart';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when a button input changes.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when button inputs change.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn eine Knopfeingabe verändert wird.
@@ -497,8 +500,8 @@ enchant.Event.INPUT_CHANGE = 'inputchange';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when a button input ends.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when button input ends.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn eine Knopf losgelassen wird.
@@ -514,8 +517,8 @@ enchant.Event.INPUT_END = 'inputend';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the left button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'left' button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Links"-Knopf gedrückt wird.
@@ -531,8 +534,8 @@ enchant.Event.LEFT_BUTTON_DOWN = 'leftbuttondown';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the left button is released.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'left' button is released.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Links"-Knopf losgelassen wird.
@@ -548,8 +551,8 @@ enchant.Event.LEFT_BUTTON_UP = 'leftbuttonup';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the right button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'right' button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Rechts"-Knopf gedrückt wird.
@@ -565,8 +568,8 @@ enchant.Event.RIGHT_BUTTON_DOWN = 'rightbuttondown';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the right button is released.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'right' button is released.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Rechts"-Knopf losgelassen wird.
@@ -582,8 +585,8 @@ enchant.Event.RIGHT_BUTTON_UP = 'rightbuttonup';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the up button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'up' button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Oben"-Knopf gedrückt wird.
@@ -599,8 +602,8 @@ enchant.Event.UP_BUTTON_DOWN = 'upbuttondown';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the up button is released.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'up' button is released.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Oben"-Knopf losgelassen wird.
@@ -616,8 +619,8 @@ enchant.Event.UP_BUTTON_UP = 'upbuttonup';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the down button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'down' button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Unten"-Knopf gedrückt wird.
@@ -633,8 +636,8 @@ enchant.Event.DOWN_BUTTON_DOWN = 'downbuttondown';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the down button is released.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'down' button is released.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "Nach Unten"-Knopf losgelassen wird.
@@ -650,8 +653,8 @@ enchant.Event.DOWN_BUTTON_UP = 'downbuttonup';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the a button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'a' button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "A"-Knopf gedrückt wird.
@@ -667,8 +670,8 @@ enchant.Event.A_BUTTON_DOWN = 'abuttondown';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the a button is released.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'a' button is released.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "A"-Knopf losgelassen wird.
@@ -684,8 +687,8 @@ enchant.Event.A_BUTTON_UP = 'abuttonup';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the b button is pressed.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'b' button is pressed.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "B"-Knopf gedrückt wird.
@@ -701,8 +704,8 @@ enchant.Event.B_BUTTON_DOWN = 'bbuttondown';
  * 発行するオブジェクト: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:en]
- * An event which is occurring when the b button is released.
- * Issued object: {@link enchant.Core}, {@link enchant.Scene}
+ * An event dispatched when the 'b' button is released.
+ * Issued by: {@link enchant.Core}, {@link enchant.Scene}
  [/lang]
  [lang:de]
  * Ereignis, welchses auftritt wenn der "B"-Knopf losgelassen wird.
@@ -715,8 +718,13 @@ enchant.Event.B_BUTTON_UP = 'bbuttonup';
 /**
  [lang:ja]
  * アクションがタイムラインに追加された時に発行されるイベント
- * @type {String}
+ * looped が設定されている時も、アクションは一度タイムラインから削除されもう一度追加される
  [/lang]
+ [lang:en]
+ * An event dispatched when an Action is added to a Timeline.
+ * When looped, an Action is removed from the Timeline and added back into it.
+ [/lang]
+ * @type {String}
  */
 enchant.Event.ADDED_TO_TIMELINE = "addedtotimeline";
 
@@ -724,6 +732,10 @@ enchant.Event.ADDED_TO_TIMELINE = "addedtotimeline";
  [lang:ja]
  * アクションがタイムラインから削除された時に発行されるイベント
  * looped が設定されている時も、アクションは一度タイムラインから削除されもう一度追加される
+ [/lang]
+ [lang:en]
+ * An event dispatched when an Action is removed from a Timeline.
+ * When looped, an Action is removed from the timeline and added back into it.
  [/lang]
  * @type {String}
  */
@@ -733,6 +745,9 @@ enchant.Event.REMOVED_FROM_TIMELINE = "removedfromtimeline";
  [lang:ja]
  * アクションが開始された時に発行されるイベント
  [/lang]
+ [lang:en]
+ * An event dispatched when an Action begins.
+ [/lang]
  * @type {String}
  */
 enchant.Event.ACTION_START = "actionstart";
@@ -740,6 +755,9 @@ enchant.Event.ACTION_START = "actionstart";
 /**
  [lang:ja]
  * アクションが終了するときに発行されるイベント
+ [/lang]
+ [lang:en]
+ * An event dispatched when an Action finishes.
  [/lang]
  * @type {String}
  */
@@ -749,6 +767,9 @@ enchant.Event.ACTION_END = "actionend";
  [lang:ja]
  * アクションが1フレーム経過するときに発行されるイベント
  [/lang]
+ [lang:en]
+ * An event dispatched when an Action has gone through one frame.
+ [/lang]
  * @type {String}
  */
 enchant.Event.ACTION_TICK = "actiontick";
@@ -757,6 +778,9 @@ enchant.Event.ACTION_TICK = "actiontick";
  [lang:ja]
  * アクションが追加された時に、タイムラインに対して発行されるイベント
  [/lang]
+ [lang:en]
+ * An event dispatched to the Timeline when an Action is added.
+ [/lang]
  * @type {String}
  */
 enchant.Event.ACTION_ADDED = "actionadded";
@@ -764,6 +788,9 @@ enchant.Event.ACTION_ADDED = "actionadded";
 /**
  [lang:ja]
  * アクションが削除された時に、タイムラインに対して発行されるイベント
+ [/lang]
+ [lang:en]
+ * An event dispatched to the Timeline when an Action is removed.
  [/lang]
  * @type {String}
  */

--- a/dev/src/EventTarget.js
+++ b/dev/src/EventTarget.js
@@ -10,9 +10,8 @@ enchant.EventTarget = enchant.Class.create({
      * ただしフェーズの概念はなし.
      [/lang]
      [lang:en]
-     * A class for an independent implementation of events
-     * similar to DOM Events.
-     * However, it does not include the phase concept.
+     * A class for implementation of events similar to DOM Events.
+     * However, it does not include the concept of phases.
      [/lang]
      [lang:de]
      * Eine Klasse für eine unabhängige Implementierung von Ereignissen 
@@ -28,20 +27,20 @@ enchant.EventTarget = enchant.Class.create({
     /**
      [lang:ja]
      * イベントリスナを追加する.
-     * @param {String} type イベントのタイプ.
-     * @param {function(e:enchant.Event)} listener 追加するイベントリスナ.
+     * @param {String} [type] イベントのタイプ.
+     * @param {function(e:enchant.Event)} [listener] 追加するイベントリスナ.
      [/lang]
      [lang:en]
      * Add a new event listener which will be executed when the event
-     * is being dispatched.
-     * @param {String} type Type of the events.
-     * @param {function(e:enchant.Event)} listener Event listener to be added.
+     * is dispatched.
+     * @param {String} [type] Type of the events.
+     * @param {function(e:enchant.Event)} [listener] Event listener to be added.
      [/lang]
      [lang:de]
      * Fügt einen neuen Ereignisbeobachter hinzu, welcher beim Auftreten des
      * Events ausgeführt wird.
-     * @param {String} type Ereignis Typ.
-     * @param {function(e:enchant.Event)} listener Der Ereignisbeobachter 
+     * @param {String} [type] Ereignis Typ.
+     * @param {function(e:enchant.Event)} [listener] Der Ereignisbeobachter 
      * der hinzugefügt wird.
      [/lang]
      */
@@ -55,10 +54,18 @@ enchant.EventTarget = enchant.Class.create({
         }
     },
     /**
+     [lang:jp]
+     * addEventListener と同じ。
+     * @see {enchant.EventTarget#addEventListener}
+     * @param {String} [type] イベントのタイプ.
+     * @param {function(e:enchant.Event)} [listener] 追加するイベントリスナ.
+     [/lang]
+     [lang:en]
      * Synonym for addEventListener
      * @see {enchant.EventTarget#addEventListener}
-     * @param {String} type Type of the events.
-     * @param {function(e:enchant.Event)} listener Event listener to be added.
+     * @param {String} [type] Type of the events.
+     * @param {function(e:enchant.Event)} [listener] Event listener to be added.
+     [/lang]
      */
     on: function() {
         this.addEventListener.apply(this, arguments);
@@ -66,18 +73,18 @@ enchant.EventTarget = enchant.Class.create({
     /**
      [lang:ja]
      * イベントリスナを削除する.
-     * @param {String} type イベントのタイプ.
-     * @param {function(e:enchant.Event)} listener 削除するイベントリスナ.
+     * @param {String} [type] イベントのタイプ.
+     * @param {function(e:enchant.Event)} [listener] 削除するイベントリスナ.
      [/lang]
      [lang:en]
      * Delete an event listener.
-     * @param {String} type Type of the events.
-     * @param {function(e:enchant.Event)} listener Event listener to be deleted.
+     * @param {String} [type] Type of the events.
+     * @param {function(e:enchant.Event)} [listener] Event listener to be deleted.
      [/lang]
      [lang:de]
      * Entfernt einen Ereignisbeobachter.
-     * @param {String} type Ereignis Typ.
-     * @param {function(e:enchant.Event)} listener Der Ereignisbeobachter 
+     * @param {String} [type] Ereignis Typ.
+     * @param {function(e:enchant.Event)} [listener] Der Ereignisbeobachter 
      * der entfernt wird.
      [/lang]
      */
@@ -93,18 +100,19 @@ enchant.EventTarget = enchant.Class.create({
     /**
      [lang:ja]
      * すべてのイベントリスナを削除する.
-     * @param [String] type イベントのタイプ.
+     * @param [String] [type] イベントのタイプ.
      [/lang]
      [lang:en]
-     * Clear all defined event listener for a given type.
-     * If no type is given, all listener will be removed.
-     * @param [String] type Type of the events.
+     [lang:en]
+     * Clear all defined event listeners of a given type.
+     * If no type is given, all listeners will be removed.
+     * @param [String] [type] Type of the events.
      [/lang]
      [lang:de]
      * Entfernt alle Ereignisbeobachter für einen Typ.
      * Wenn kein Typ gegeben ist, werden alle 
      * Ereignisbeobachter entfernt.
-     * @param [String] type Ereignis Typ.
+     * @param [String] [type] Ereignis Typ.
      [/lang]
      */
     clearEventListener: function(type) {
@@ -117,15 +125,15 @@ enchant.EventTarget = enchant.Class.create({
     /**
      [lang:ja]
      * イベントを発行する.
-     * @param {enchant.Event} e 発行するイベント.
+     * @param {enchant.Event} [e] 発行するイベント.
      [/lang]
      [lang:en]
      * Issue an event.
-     * @param {enchant.Event} e Event to be issued.
+     * @param {enchant.Event} [e] Event to be issued.
      [/lang]
      [lang:de]
      * Löst ein Ereignis aus.
-     * @param {enchant.Event} e Ereignis das ausgelöst werden soll.
+     * @param {enchant.Event} [e] Ereignis das ausgelöst werden soll.
      [/lang]
      */
     dispatchEvent: function(e) {


### PR DESCRIPTION
I copied all of my translations from the main enchant.js file to the
source files.

I also cleaned up my work in a couple of places. In general, I've been
cleaning up little things like encasing parameter names in [] for
@param lines. Specific changes are listed below.

Core.js -- I finished going through its docs.
Event.js -- There were a lot of little things which were grammatically
correct and matched the wording of the Japanese documentation but which
didn't follow standard practices for programming documentation in
English. I cleaned that up.
EventTarget.js -- Added Japanese for EventTarget.on().

Concerns:

Core.js
- Lines 246 and 249 in my commit -- Should the documentation say
  game.start() or Core.start()?
- Lines 926 and 951 in my commit -- Should these really be the same?
  And should they really link to Core.start() instead of Core.resume()?
