### PR TITLE
Spriteをモデルとして扱い、モデルのフィールドデータを監視したい(再)

### DIFF
--- a/dev/plugins/model.enchant.js
+++ b/dev/plugins/model.enchant.js
@@ -1,0 +1,331 @@
+/**
+ * @fileOverview
+ * observer.sprite.enchant.js v2 (2013/09/30)
+ * 
+ * enchant では Sprite Class をモデルとする、
+ * つまり Sprite Class に HP などの状態を持たせる書き方が多い。
+ * その際に Sprite 同士の連携を直接とる場合が出てくる。
+ * 例えば、プレイヤー (Sprite) の HP が減った時に 
+ * HP を表現するバー (Sprite) を減少させる場合などが想定される。
+ * その時、実装手法は プレイヤーの HP が減少したというイベントに対し、
+ * イベントリスナを加えるとよいと思われる。
+ * 
+ * 本プラグインでは Sprite をモデルと捉え、モデルのデータを監視し、
+ * データ変更が確認された場合、他の Sprite 等に通知する Observer Pattern
+ * を適用したSpriteの拡張クラスを提供する。
+ *
+ * @require enchant.js v0.8.0 or later
+ * @author Taketo Yoshida.
+ *
+ * @features
+ * [lang:ja]
+ * Sprite Class にモデルの機能を持たせたクラス
+ * そのモデルのフィールドにオブザーバーを追加することができる
+ * [/lang]
+ * [lang:en]
+ * Sprite Class with Model
+ * It is possible to add a field to the observer of the sprite
+ * [/lang]
+ *
+ * @usage
+ *
+ * sp = new SpriteModel(16, 16);
+ * sp.backgroundColor = "red";
+ * sp.x = 32;
+ * sp.y = 32;
+ *
+ * sp.setup("key", "test");
+ * sp.on("key", function(data){ console.log("fire1:" + data) });
+ * sp.on("key", function(data){ console.log("fire2:" + data) });
+ * sp.set("key", 16);
+ * # fire1:16
+ * # fire1:16
+ * console.log(sp.key)
+ * # 16
+ * sp.key = "test";
+ * # fire1:test
+ * # fire1:test
+ * console.log(sp.get("key"))
+ * # test
+ * game.rootScene.addChild(sp);
+ *
+ */
+(function() {
+
+    enchant.model = {};
+
+    /**
+     * 監視対象のオブジェクト
+     */
+    var Observable = enchant.Class.create({
+
+        /**
+         * @constructs
+         * @param value
+         *   オブジェクトの値
+         */
+        initialize: function(value) {
+            this._value = value;
+            this._subscribers = [];
+        },
+
+        value: {
+            get: function() {
+                return this._value;
+            },
+            set: function(value) {
+                this._value = value;
+                this._publish(value);
+            }
+        },
+
+        /**
+         * listenerを追加する
+         * @param listener
+         */
+        subscribe: function(listener) {
+            this._subscribers.push(listener);
+        },
+
+        /**
+         * listenerを破棄する
+         * @param listener
+         */
+        unsubscribe: function(listener) {
+            var i = 0,
+                len = this._subscribers.length;
+            for (; i < len; i++) {
+                if (this._subscribers[i] === listener) {
+                    this._subscribers.splice(i, 1);
+                    return;
+                }
+            }
+        },
+
+        /**
+         * listenerをすべて破棄する
+         */
+        clear: function() {
+            this._subscribers.length = 0;
+        },
+
+        /**
+         * 関連付けられているlistenerをすべて呼ぶ
+         */
+        _publish: function(data) {
+            var i = 0,
+                len = this._subscribers.length;
+            for (; i < len; i++) {
+                this._subscribers[i](data);
+            }
+        }
+    });
+
+    var hookObserver = function(arr, name, hook) {
+        arr[name] = hook;
+    };
+
+    var ArrayObservable = enchant.Class.create(Observable, {
+        /**
+         * @constructs
+         * @param value
+         *   オブジェクトの値
+         */
+        initialize: function(value) {
+            Observable.call(this, value);
+            this._initializeArrayValue();
+        },
+
+        /**
+         * push, pop, shift, unshiftを監視対象に加える
+         */
+        _initializeArrayValue: function() {
+            var observable = this;
+            // hook push method
+            this._value._push = this._value.push;
+            hookObserver(this._value, "push", function(d){
+                for (var i = 0; i < arguments.length; i++) {
+                    observable._value._push(arguments[i]);
+                }
+                observable._publish(arguments.length == 1 ? d : arguments, "push");
+            });
+
+            // hook pop method
+            this._value._pop = this._value.pop;
+            hookObserver(this._value, "pop", function(){
+                var d = observable._value._pop();
+                observable._publish(d, "pop");
+            });
+
+            // hook unshift method
+            this._value._unshift = this._value.unshift;
+            hookObserver(this._value, "unshift", function(d){
+                for (var i = 0; i < arguments.length; i++) {
+                    observable._value._unshift(arguments[i]);
+                }
+                observable._publish(arguments.length == 1 ? d : arguments, "unshift");
+            });
+
+            // hook shift method
+            this._value._shift = this._value.shift;
+            hookObserver(this._value, "shift", function(){
+                var d = observable._value._shift();
+                observable._publish(d, "shift");
+            });
+        },
+
+        /**
+         * override
+         *  listenerの2番目の引数にメソッド名が入る
+         */
+        _publish: function(data, method) {
+            var i = 0,
+                len = this._subscribers.length;
+            for (; i < len; i++) {
+                this._subscribers[i](data, method);
+            }
+        }
+    });
+
+    /**
+     * Subject
+     *  登録されたデータフィールドを監視して、
+     *  更新された場合リスナーを呼ぶ
+     */
+    var Subject = {
+        _prefix : "_",
+
+        /**
+         * 監視対象のフィールドを初期化して追加する
+         * @param key
+         * @param value
+         * @usage
+         *  値の場合:
+         *  model.setup("key", "value");
+         *
+         *  配列の場合:
+         *  model.setup("key", []);
+         *  model.setup("key", [0, 1]);
+        */
+        setup: function(key, value) {
+            if (value instanceof Array) {
+                this[this._prefix + key] = new ArrayObservable(value);
+            } else {
+                this[this._prefix + key] = new Observable(value);
+            }
+            Object.defineProperty(this, key, {
+                get: function() {
+                    return this[this._prefix + key].value;
+                },
+                set: function(value) {
+                    return this[this._prefix + key].value = value;
+                },
+            });
+        },
+
+        /**
+         * 監視対象のフィールドを更新する
+         * @param key
+         * @param value
+         */
+        set: function(key, value) {
+            if (this[this._prefix + key] instanceof Observable) {
+                this[key] = value;
+            } else {
+                this.setup(key, value);
+            }
+            return value;
+        },
+
+        /**
+         * 監視対象のフィールドを取得する
+         * @param key
+         */
+        get: function(key) {
+            return this[this._prefix + key] instanceof Observable ? this[key] : null;
+        },
+
+        /**
+         * 監視対象のフィールドにリスナーを設定する
+         * @usage
+         *    値の場合:
+         *    model.on("key", function(data){ console.log("fire: " + data); });
+         *    model.key = "test"; // or model.set("key", "test")
+         *    // fire: test
+         *    // => "test"
+         *
+         *    配列の場合:
+         *    model.on("arr", function(data, method){ console.log(method + " : " + data); });
+         *    model.arr.push("test");
+         *    // push : test
+         *    // => "test"
+         *    model.arr.pop();
+         *    // pop : test
+         *    // => "test"
+         *  
+         * @param key
+         *  フィールドのキー
+         * @param listener
+         *  監視対象のフィールドが更新された時によばれるリスナー
+         */
+        on: function(key, listener) {
+            if (this[this._prefix + key] instanceof Observable) {
+                this[this._prefix + key].subscribe(listener);
+            }
+        },
+
+        /**
+         * 監視対象のフィールドにリスナーを削除する
+         * @param key
+         *  フィールドのキー
+         * @param listener
+         *  監視対象にすでに登録されているリスナー
+         */
+        off: function(key, listener) {
+            if (this[this._prefix + key] instanceof Observable) {
+                this[this._prefix + key].unsubscribe(listener);
+            }
+        },
+
+        /**
+         * 監視対象のフィールドにリスナーをすべて削除する
+         * @param key
+         *  フィールドのキー
+         */
+        clearObserver: function(key) {
+            if (this[this._prefix + key] instanceof Observable) {
+                this[this._prefix + key].clear();
+            } 
+        }
+
+    };
+
+    /**
+     * Observer Pattern が適用された Sprite
+     * @scope enchant.model.SpriteModel
+     */
+    Subject['initialize'] =
+      /**
+       * @constructs
+       * @extends enchant.Sprite
+       */
+      function(width, height) {
+          enchant.Sprite.call(this, width, height);
+      };
+    enchant.model.SpriteModel = enchant.Class.create(enchant.Sprite, Subject);
+
+    /**
+     * Observer Pattern が適用された Group
+     * @scope enchant.model.GroupModel
+     */
+    Subject['initialize'] =
+      /**
+       * @constructs
+       * @extends enchant.Group
+       */
+      function() {
+          enchant.Group.call(this);
+      };
+    enchant.model.GroupModel = enchant.Class.create(enchant.Group, Subject);
+
+})();

--- a/examples/plugins/model/index.html
+++ b/examples/plugins/model/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no"> 
+        <meta name="apple-mobile-web-app-capable" content="yes"> 
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <title>enchant</title>
+        <script type="text/javascript" src="../../../dev/enchant.js"></script>
+        <script type="text/javascript" src="../../../dev/plugins/model.enchant.js"></script>
+        <script type="text/javascript" src="main.js"></script>
+        <style type="text/css">
+            body {
+                margin: 0;
+            }
+        </style>
+    </head>
+    <body>
+    </body>
+</html>

--- a/examples/plugins/model/main.js
+++ b/examples/plugins/model/main.js
@@ -1,0 +1,60 @@
+
+/**
+ * PlayerのモデルのHPが減った時に、
+ * そのイベントを監視してラベルを更新するプログラム。
+ * なお、プレイヤーは便宜上16x16の赤色四角で表現する。
+ */
+
+enchant();
+window.onload = function(){
+    game = new Game(320, 320);
+    game.preload();
+    game.fps = 30;
+    game.onload = function(){
+        var label = new Label("HP: 1000");
+        label.x = 64;
+        label.y = 32;
+
+        var player = new SpriteModel(16, 16);
+        player.x = 32;
+        player.y = 32;
+        player.backgroundColor = "red";
+
+
+        player.setup("hp", 1000);
+        player.setup("bullets", ["test0"]);
+
+        // add observer to bullet array
+        player.on("bullets", function(data, method){
+            console.log(method + " bullet: " + data);
+        });
+        player.bullets.push("test1");
+        player.bullets.push("test2");
+        player.bullets.unshift("test3", "test4");
+        player.bullets.shift();
+        player.bullets.pop();
+        console.log("display all bullets");
+        player.bullets.forEach(function(d){
+            console.log(d);
+        });
+
+        // add observer to hp
+        player.on("hp", function(data){
+            if (data > 0) {
+                label.text = "HP: " + data;
+            } else {
+                label.text = "player die ..."
+            }
+        });
+
+        game.rootScene.addChild(label);
+        game.rootScene.addChild(player);
+
+        setInterval(function(){
+            player.hp -= 10;
+            // or player.set("hp", player.hp - 10)
+        }, 500);
+    }
+    game.start();
+}
+


### PR DESCRIPTION
Enchantにおいて以下のようにSpriteを拡張してモデルとして扱っている(例えばプレイヤーのHPとかをSpriteのメンバ変数にいれるなどの)コードを書くと思うのですが、

``` javascript
var player = enchant.Class.create(enchant.Sprite, {
    initalize: function(width, height){
        enchant.Sprite.call(this, width, height);
        this.hp = 1000:
    } 
});
```

ここで、例えばプレイヤーのHPが減った際にHPバーのゲージを下げるという処理を書くとします。

その時にイベントハンドラとしてプレイヤーのHPが減ったというイベントを監視する、つまりはプレイヤーのモデルのフィールドデータに対してObserver Patternを適用できれば便利かなと思いました。

この実装をフレームワークが面倒を見るかは分からないのでもし良かったら追加お願いします。
プラグインとして追加したので他に影響を出すことはないと思います。

(追記)
インデントが揃ってない部分があったので最後送らせていただきます。
