### PR TITLE
fix android JSON.parse(null) bug

### DIFF
--- a/dev/plugins/memory.enchant.js
+++ b/dev/plugins/memory.enchant.js
@@ -664,7 +664,8 @@
             this._user_memory_key = "game_" + game_id + "_user_";
         },
         get_user_memory: function(key) {
-            var ret = JSON.parse(localStorage.getItem(this._user_memory_key + key));
+            var value = localStorage.getItem(this._user_memory_key + key);
+            var ret = value ? JSON.parse(value) : null;
             if (ret == null) return {'data': {}};
             ret.toSprite = function(width, height) {
                 if (arguments.length < 2) {


### PR DESCRIPTION
bug fix for Android JSON.parse bug
## Error message

```
Uncaught illegal access at file:///android_asset/www/plugins/memory.enchant.js:667
```
## See also

See also for same bug

Android + JSON.parse(NULL) = Uncaught illegal access · Issue #48 · brianleroux/lawnchair
https://github.com/brianleroux/lawnchair/issues/48

In Japanese
http://metamosoft.hatenablog.com/entry/2013/06/16/143156
