### PR TITLE
fix "touch to start" issue on iOS for issue #260

### DIFF
--- a/dev/src/Core.js
+++ b/dev/src/Core.js
@@ -743,8 +743,8 @@
                     var width = sprite.image.context.measureText('Touch to Start').width;
                     sprite.image.context.fillText('Touch to Start', (core.width - width) / 2, size - 1);
                     scene.addChild(sprite);
-                    document.addEventListener('mousedown', function waitTouch() {
-                        document.removeEventListener('mousedown', waitTouch);
+                    document.addEventListener('touchstart', function waitTouch() {
+                        document.removeEventListener('touchstart', waitTouch);
                         core._touched = true;
                         core.removeScene(scene);
                         core.start(d);


### PR DESCRIPTION
Use touch start events instead of mousedown events for iOS
NOTE: simulated browsers actually will produce mousedown events, but actual device will not