### PR TITLE
fix unbinding bug

### DIFF
--- a/dev/src/BinaryInputManager.js
+++ b/dev/src/BinaryInputManager.js
@@ -103,8 +103,8 @@ enchant.BinaryInputManager = enchant.Class.create(enchant.InputManager, {
      * @see enchant.InputManager#unbind
      */
     unbind: function(binaryInputSource) {
-        enchant.InputManager.prototype.unbind.call(this, binaryInputSource);
         var name = this._binds[binaryInputSource.identifier];
+        enchant.InputManager.prototype.unbind.call(this, binaryInputSource);
         delete this.valueStore[name];
     },
     /**


### PR DESCRIPTION
BinaryInputManager#unbind で、InputManagerのunbindを呼んだ後に、nameを取得している。  
そのため、タイミングによってはnameがundefinedとなり、続く delete が実行されず正しくunbindされない場合がある。

nameの取得タイミングを変更することで、この不具合を回避するように修正しました。
