### PR TITLE
touchEnabled = falseのEntityなどはイベントを中断していました。

### DIFF
--- a/dev/src/Scene.js
+++ b/dev/src/Scene.js
@@ -196,7 +196,9 @@ enchant.Scene = enchant.Class.create(enchant.Group, {
             layer = this._layers[this._layerPriority[i]];
             target = layer._determineEventTarget(e);
             if (target) {
-                break;
+                if (target.touchEnabled) {
+                    break;   
+                }
             }
         }
         if (!target) {


### PR DESCRIPTION
touchEnabledのEntityが他のtouchEnabledのEntityの上にかぶってしまうとイベントはenabled==falseのEntityで受け取れて、イベントの目的のenabled==trueのEntityまで届けません
