### PR TITLE
remove unused code

### DIFF
--- a/dev/src/CanvasLayer.js
+++ b/dev/src/CanvasLayer.js
@@ -148,11 +148,6 @@ enchant.CanvasLayer = enchant.Class.create(enchant.Group, {
         childAdded.next = null;
         this.dispatchEvent(childAdded);
         node.dispatchEvent(new enchant.Event('added'));
-        if (this.scene) {
-            node.scene = this.scene;
-            var addedToScene = new enchant.Event('addedtoscene');
-            node.dispatchEvent(addedToScene);
-        }
     },
     insertBefore: function(node, reference) {
         var i = this.childNodes.indexOf(reference);
@@ -164,11 +159,6 @@ enchant.CanvasLayer = enchant.Class.create(enchant.Group, {
             childAdded.next = reference;
             this.dispatchEvent(childAdded);
             node.dispatchEvent(new enchant.Event('added'));
-            if (this.scene) {
-                node.scene = this.scene;
-                var addedToScene = new enchant.Event('addedtoscene');
-                node.dispatchEvent(addedToScene);
-            }
         } else {
             this.addChild(node);
         }


### PR DESCRIPTION
CanvasLayerの`#addChild` `#insertBefore` で CanvasLayerには存在しない `this.scene` の存在を確認してイベントをdispatchする処理があるが、この部分は呼ばれることがありません。
Sceneに対して`#addChild` `#insertBefore` した場合は Groupにあるそれぞれのメソッドで、ここで意図している処理が行われるので、この処理を削除しました。
テストは別途 feature/mocha_canvasrender にコミットします。
