### PR TITLE
Changed the calculation of the elapsed time between two frames.

### DIFF
--- a/dev/src/Core.js
+++ b/dev/src/Core.js
@@ -891,6 +891,7 @@
             var e = new enchant.Event('enterframe');
             var now = window.getTime();
             var elapsed = e.elapsed = now - this.currentTime;
+            this.currentTime = now;
 
             this._actualFps = elapsed > 0 ? (1000 / elapsed) : 0;
 
@@ -912,7 +913,7 @@
             this.dispatchEvent(new enchant.Event('exitframe'));
             this.frame++;
             now = window.getTime();
-            this.currentTime = now;
+            
             this._requestNextFrame(1000 / this.fps - (now - this._calledTime));
         },
         getTime: function() {


### PR DESCRIPTION
Previously the elapsed time ignored the time to render on frame. Now this time is also included to fix issues with time based animations within larger applications where the rendering of one frame cannot be neglected.

Detailed Explanation (timestamps A_X, B_X):

A_0
render frame 0
B_0
A_1
render frame 1
B_1
…

Previous calculation:
elapsed(N) = A_N - B_(N-1)
           = A_N - A_(N-1) - time for rendering frame (N-1)

New calculation:
elapsed(N) = A_N - A_(N-1)
           = A_N - B_(N-1) + time for rendering frame (N-1)
