### PR TITLE
Space Key (32) from the enchant.ENV.KEY_BIND_TABLE example has been defined in the PREVENT_DEFAULT_KEY_CODES by default.

### DIFF
--- a/dev/src/Env.js
+++ b/dev/src/Env.js
@@ -198,7 +198,7 @@ enchant.ENV = {
      [/lang]
      * @type Number[]
      */
-    PREVENT_DEFAULT_KEY_CODES: [37, 38, 39, 40, 32],
+    PREVENT_DEFAULT_KEY_CODES: [37, 38, 39, 40],
     /**
      [lang:ja]
      * Mobile Safariでサウンドの再生を有効にするかどうか.


### PR DESCRIPTION
Space Key (32) from the enchant.ENV.KEY_BIND_TABLE example has been defined in the PREVENT_DEFAULT_KEY_CODES by default.

I think, that only events defined in the KEY_BIND_TABLE should be
defined in the PREVENT_DEFAULT_KEY_CODES by default
