### PR TITLE
Fixed webkit audio issue

### DIFF
--- a/dev/src/WebAudioSound.js
+++ b/dev/src/WebAudioSound.js
@@ -47,7 +47,7 @@ enchant.WebAudioSound = enchant.Class.create(enchant.EventTarget, {
      */
     play: function(dup) {
         if (this._state === 1 && !dup) {
-            this.src.disconnect(this.connectTarget);
+            this.src.disconnect();
         }
         if (this._state !== 2) {
             this._currentTime = 0;


### PR DESCRIPTION
As mentioned here:
https://github.com/wise9/enchant.js/issues/312
This was causing Chrome to crash when attempting to disconnect a sound. The error given was:

Uncaught InvalidAccessError: Failed to execute 'disconnect' on 'AudioNode'