### PR TITLE
Feature package update

### DIFF
--- a/dev/src/Sprite.js
+++ b/dev/src/Sprite.js
@@ -230,7 +230,8 @@ enchant.Sprite = enchant.Class.create(enchant.Entity, {
             w = this._width, h = this._height,
             iw, ih, elem, sx, sy, sw, sh;
         if (image && w !== 0 && h !== 0) {
-            iw = image.width, ih = image.height;
+            iw = image.width;
+            ih = image.height;
             if (iw < w || ih < h) {
                 ctx.fillStyle = enchant.Surface._getPattern(image);
                 ctx.fillRect(0, 0, w, h);

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "test": "grunt default --verbose"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-contrib-jshint": "0.2.0",
-    "grunt-contrib-concat": "0.1.3",
-    "grunt-contrib-uglify": "0.1.2",
-    "grunt-contrib-qunit": "0.2.1",
-    "grunt-contrib-watch": "0.3.1",
-    "grunt-exec": "0.4.0",
-    "grunt-mocha": "~0.4.1",
-    "unzip": "~0.1.9"
+    "grunt": "~0.4.5",
+    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-concat": "0.5.1",
+    "grunt-contrib-uglify": "0.9.2",
+    "grunt-contrib-qunit": "0.7.0",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-exec": "0.4.6",
+    "grunt-mocha": "~0.4.13",
+    "unzip": "~0.1.11"
   }
 }


### PR DESCRIPTION
update all packages, adjusted Sprite assignment to match style rule.
jshint v0.11.0 has been released in 2015/01 however newer versions than
v0.10.0 do not support style guidelines
jscs is required for this now
http://jscs.info/overview

https://github.com/wise9/enchant.js/issues/314