### PR TITLE
Fix broken documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ Documentation
 -------------
 
 - English
-    - <http://wise9.github.com/enchant.js/doc/core/en/index.html>
-    - <http://wise9.github.com/enchant.js/doc/plugins/en/index.html> (with plugins)
+    - <https://wise9.github.io/enchant.js/doc/core/en/index.html>
+    - <https://wise9.github.io/enchant.js/doc/plugins/en/index.html> (with plugins)
 - Deutsch (German)
-    - <http://wise9.github.com/enchant.js/doc/core/de/index.html>
-    - <http://wise9.github.com/enchant.js/doc/plugins/de/index.html> (with plugins)
+    - <https://wise9.github.io/enchant.js/doc/core/de/index.html>
+    - <https://wise9.github.io/enchant.js/doc/plugins/de/index.html> (with plugins)
 - Japanese
-    - <http://wise9.github.com/enchant.js/doc/core/ja/index.html>
-    - <http://wise9.github.com/enchant.js/doc/plugins/ja/index.html> (with plugins)
-- See also [enchantjs.com](http://enchantjs.com)
+    - <https://wise9.github.io/enchant.js/doc/core/ja/index.html>
+    - <https://wise9.github.io/enchant.js/doc/plugins/ja/index.html> (with plugins)
 
 Design
 ------
@@ -63,7 +62,7 @@ Usage
 </script>
 ```
 
-More examples and references: [enchantjs.com](http://enchantjs.com)
+More examples and references: [GitHub Repository](https://github.com/wise9/enchant.js)
 
 How to build
 ------------


### PR DESCRIPTION
## Summary
- Update GitHub Pages URLs from defunct `wise9.github.com` to `wise9.github.io`
- Update protocol from HTTP to HTTPS
- Remove references to expired `enchantjs.com` domain

Fixes #342

## Test plan
- [x] Verified that `https://wise9.github.io/enchant.js/doc/core/en/index.html` loads correctly
- [x] Confirmed `enchantjs.com` is no longer accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)